### PR TITLE
Add GA4 tracking tag

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -14,6 +14,7 @@
 			}
 			gtag('js', new Date());
 			gtag('config', 'AW-11464920859');
+			gtag('config', 'G-XQ3RMF0HWH');
 		</script>
 
 		%sveltekit.head%

--- a/src/app.html.test.ts
+++ b/src/app.html.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, test } from 'vitest';
+
+const appHtml = readFileSync('src/app.html', 'utf8');
+
+describe('app document analytics tags', () => {
+	test('configures Google Ads and Analytics from one global head tag', () => {
+		expect(appHtml.match(/googletagmanager\.com\/gtag\/js/g)).toHaveLength(1);
+		expect(appHtml).toContain(
+			'<script async src="https://www.googletagmanager.com/gtag/js?id=AW-11464920859"></script>'
+		);
+		expect(appHtml).toContain("gtag('config', 'AW-11464920859');");
+		expect(appHtml).toContain("gtag('config', 'G-XQ3RMF0HWH');");
+		expect(appHtml.indexOf('googletagmanager.com/gtag/js')).toBeLessThan(
+			appHtml.indexOf('%sveltekit.head%')
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- Add GA4 measurement ID `G-XQ3RMF0HWH` to the existing global Google tag setup
- Keep a single shared `gtag.js` loader in `src/app.html` so tracking applies across all SvelteKit routes
- Add a regression test to verify the global Google tag config includes both Ads and GA4 IDs

## Verification

- `pnpm --config.engine-strict=false exec vitest run src/app.html.test.ts`
